### PR TITLE
Fix character encoding in HTTP requests

### DIFF
--- a/lib/zoning/endpoints/jurisdictions.rb
+++ b/lib/zoning/endpoints/jurisdictions.rb
@@ -19,7 +19,7 @@ module Zoning
 			if parse
 				Zoning::Connection.parse(connection)
 			else
-				connection.body
+				Zoning::Connection.verify(connection)
 			end
 		end
 


### PR DESCRIPTION
Adapt a bunch of code from HTTParty to handle character encoding properly. Who knows when we'll encounter a fancy non-ascii character in any of the metadata, so we'd best do the *right* thing here instead of going back to the old parse-then-unparse behavior, which would probably break if we had unicode chars show up.

Kind of ridiculous.